### PR TITLE
Enable copying of input current values

### DIFF
--- a/addon-test-support/backstop.js
+++ b/addon-test-support/backstop.js
@@ -22,6 +22,13 @@ function copyAttributesToBodyCopy(bodyCopy, testingContainer) {
   Object.keys(attributesToCopy).forEach(key => copyAttr(attributesToCopy[key]));
 }
 
+function prepareInputValuesForCopying(snapshotRoot) {
+  snapshotRoot.querySelectorAll('input')
+    .forEach(function (item) {
+      item.setAttribute('value', item.value);
+    });
+}
+
 function getDoctype() {
   let doctypeNode = document.doctype;
   if (!doctypeNode || !doctypeNode.name) {
@@ -100,6 +107,8 @@ function backstopHelper(name, testHash, options, res, err) {
   } else {
     snapshotRoot = testingContainer;
   }
+
+  prepareInputValuesForCopying(snapshotRoot);
 
   let snapshotHtml = snapshotRoot.innerHTML;
 


### PR DESCRIPTION
Input elements have an attribute and a property named "value".
The attribute holds initial value, the property holds the current value
More info: https://stackoverflow.com/questions/44451448/get-html-with-current-input-values

Fetching data from the server and bounding it to "value" the attribute
is not populated and not copied to snapshot => snapshot does not
contain input values filled.