### PR TITLE
clean up overrideCSS.js

### DIFF
--- a/blueprints/ember-backstop/files/ember-backstop/backstop_data/engine_scripts/puppet/overrideCSS.js
+++ b/blueprints/ember-backstop/files/ember-backstop/backstop_data/engine_scripts/puppet/overrideCSS.js
@@ -1,14 +1,12 @@
 /* eslint-env browser, node */
 
-const BACKSTOP_TEST_CSS_OVERRIDE = `#ember-testing {width: 100% !important; height: 100% !important; -webkit-transform: scale(1) !important; transform: scale(1) !important;}`;
-
 module.exports = function(page, scenario) {
   // inject arbitrary css to override styles
-  page.evaluate(`window._styleData = '${BACKSTOP_TEST_CSS_OVERRIDE}'`);
   page.evaluate(() => {
+    const BACKSTOP_TEST_CSS_OVERRIDE = `#ember-testing {width: 100% !important; height: 100% !important; -webkit-transform: scale(1) !important; transform: scale(1) !important;}`;
     let style = document.createElement('style');
     style.type = 'text/css';
-    let styleNode = document.createTextNode(window._styleData);
+    let styleNode = document.createTextNode(BACKSTOP_TEST_CSS_OVERRIDE);
     style.appendChild(styleNode);
     document.head.appendChild(style);
   });

--- a/ember-backstop/backstop_data/engine_scripts/puppet/overrideCSS.js
+++ b/ember-backstop/backstop_data/engine_scripts/puppet/overrideCSS.js
@@ -1,14 +1,12 @@
 /* eslint-env browser, node */
 
-const BACKSTOP_TEST_CSS_OVERRIDE = `#ember-testing {width: 100% !important; height: 100% !important; -webkit-transform: scale(1) !important; transform: scale(1) !important;}`;
-
 module.exports = function(page, scenario) {
   // inject arbitrary css to override styles
-  page.evaluate(`window._styleData = '${BACKSTOP_TEST_CSS_OVERRIDE}'`);
   page.evaluate(() => {
+    const BACKSTOP_TEST_CSS_OVERRIDE = `#ember-testing {width: 100% !important; height: 100% !important; -webkit-transform: scale(1) !important; transform: scale(1) !important;}`;
     let style = document.createElement('style');
     style.type = 'text/css';
-    let styleNode = document.createTextNode(window._styleData);
+    let styleNode = document.createTextNode(BACKSTOP_TEST_CSS_OVERRIDE);
     style.appendChild(styleNode);
     document.head.appendChild(style);
   });


### PR DESCRIPTION
By moving the variable `BACKSTOP_TEST_CSS_OVERRIDE` inside the anonymous function passed to `page.evaluate`, the redundant call to `page.evaluate` can be avoided.

Tested this change with [super-rentals](https://github.com/ember-learn/super-rentals) repo.