### PR TITLE
Added No Console ESLint Rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     browser: true
   },
   rules: {
+    "no-console": 0
   },
   overrides: [
     // node files


### PR DESCRIPTION
Added a line to the ESLint Rules file to ensure that ESLint does not capture the no-console error. 
This solves #29  