### PR TITLE
Removed reference to a non-existent file

### DIFF
--- a/blueprints/ember-backstop/files/ember-backstop/backstop.js
+++ b/blueprints/ember-backstop/files/ember-backstop/backstop.js
@@ -13,7 +13,6 @@ module.exports = {
   scenarios: [
     {
       label: '{testName}',
-      cookiePath: 'backstop_data/engine_scripts/cookies.json',
       url: '{origin}/backstop/dview/{testId}/{scenarioId}',
       delay: 500,
     },

--- a/ember-backstop/backstop.js
+++ b/ember-backstop/backstop.js
@@ -13,7 +13,6 @@ module.exports = {
   scenarios: [
     {
       label: '{testName}',
-      cookiePath: 'backstop_data/engine_scripts/cookies.json',
       url: '{origin}/backstop/dview/{testId}/{scenarioId}',
       delay: 500,
     },


### PR DESCRIPTION
The file `backstop_data/engine_scripts/cookies.json` does not exist anymore in the repo, but the reference to it does. 

Hence deleting the reference to it.