### PR TITLE
Use Environment variable(ENABLE_BACKSTOP) to enable/disable backstop assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,39 @@ Add this to your `<project>/testem.js`...
   },
 ```
 
+## Configuration
+
+By default, `ember-backstop` will _not_ take screenshots. To enable taking screenshots do the following:
+
+1. When running ember commands like `ember s`, `ember test`, etc., use the environment variable `ENABLE_BACKSTOP=true`
+
+_Example:_
+
+When running `ember test`, run it as:
+
+```
+ENABLE_BACKSTOP=true ember test
+```
+
+2. Add the below config object to `environment.js`:
+
+```js
+/* environment.js */
+
+module.exports = function(environment) {
+  let ENV = {
+    /* ... other existing configs ABOVE this line */
+
+    'ember-backstop': {
+      enableBackstop: process.env.ENABLE_BACKSTOP
+    }
+
+    /* ... other existing configs BELOW this line */
+  };
+  return ENV;
+};
+```
+
 Usage
 ------------------------------------------------------------------------------
 ### Backstop-remote service

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Usage
 ### Backstop-remote service
 You will need the backstop-remote service running for visual tests.
 
-In a seperate window run...
+In a separate window run...
 
 ```
 ember backstop-remote
@@ -170,7 +170,7 @@ You can configure BackstopJS scenario options for your tests dynamically by pass
   });
 ```
 
-See [Scenario Documention](https://github.com/garris/BackstopJS#advanced-scenarios) for what you can configure.
+See [Scenario Documentation](https://github.com/garris/BackstopJS#advanced-scenarios) for what you can configure.
 
 #### Name Option
 You can add a custom name segment to your backstop test artifacts by passing a `name` property in the options.

--- a/README.md
+++ b/README.md
@@ -51,19 +51,9 @@ Add this to your `<project>/testem.js`...
 
 ## Configuration
 
-By default, `ember-backstop` will _not_ take screenshots. To enable taking screenshots do the following:
+By default, `ember-backstop` will take screenshots.
 
-1. When running ember commands like `ember s`, `ember test`, etc., use the environment variable `ENABLE_BACKSTOP=true`
-
-_Example:_
-
-When running `ember test`, run it as:
-
-```
-ENABLE_BACKSTOP=true ember test
-```
-
-2. Add the below config object to `environment.js`:
+To disable this behavior, add the below config object to `environment.js`:
 
 ```js
 /* environment.js */
@@ -73,7 +63,7 @@ module.exports = function(environment) {
     /* ... other existing configs ABOVE this line */
 
     'ember-backstop': {
-      enableBackstop: process.env.ENABLE_BACKSTOP
+      disableBackstop: process.env.DISABLE_BACKSTOP === 'true'
     }
 
     /* ... other existing configs BELOW this line */
@@ -81,6 +71,8 @@ module.exports = function(environment) {
   return ENV;
 };
 ```
+
+Then set the environment variable, `DISABLE_BACKSTOP=true` when running commands(for example: _ember s_, _ember test_, _ember exam_, etc.,).
 
 Usage
 ------------------------------------------------------------------------------

--- a/addon-test-support/backstop.js
+++ b/addon-test-support/backstop.js
@@ -207,9 +207,27 @@ function validateName(name) {
 }
 
 /**
+ * Reads environment.js config from the meta tag in test page, and returns the config object related to this addon.
+ */
+function getAddonCfgFromParentApp() {
+  const appEnvConfig = document.querySelector('meta[name*="config/environment"]').getAttribute('content');
+  return JSON.parse(decodeURIComponent(appEnvConfig))['ember-backstop'];
+}
+
+/**
  * I'm in your webapps -- checkin your screenz. -schooch
  */
 export default async function (assert, options) {
+  const { enableBackstop } = getAddonCfgFromParentApp();
+
+  if (enableBackstop !== 'true') {
+    assert.ok(
+      true,
+      `Backstop assertion was not run since it's currently disabled. To enable it, set environment variable, ENABLE_BACKSTOP=true`
+    );
+    return Promise.resolve(true);
+  }
+
   const hash = createNameHash(assert, options);
   return new Promise((res, err) => {
     backstopHelper(hash.name, hash.testHash, options, res, err);

--- a/addon-test-support/backstop.js
+++ b/addon-test-support/backstop.js
@@ -211,19 +211,19 @@ function validateName(name) {
  */
 function getAddonCfgFromParentApp() {
   const appEnvConfig = document.querySelector('meta[name*="config/environment"]').getAttribute('content');
-  return JSON.parse(decodeURIComponent(appEnvConfig))['ember-backstop'];
+  return JSON.parse(decodeURIComponent(appEnvConfig))['ember-backstop'] || {};
 }
 
 /**
  * I'm in your webapps -- checkin your screenz. -schooch
  */
 export default async function (assert, options) {
-  const { enableBackstop } = getAddonCfgFromParentApp();
+  const { disableBackstop } = getAddonCfgFromParentApp();
 
-  if (enableBackstop !== 'true') {
+  if (disableBackstop) {
     assert.ok(
       true,
-      `Backstop assertion was not run since it's currently disabled. To enable it, set environment variable, ENABLE_BACKSTOP=true`
+      `Backstop assertion was not run since it's currently disabled.`
     );
     return Promise.resolve(true);
   }


### PR DESCRIPTION
Backstop assertions _should not_ be run by default, since it may have unintended negative consequences like failing tests(first time tests run without established reference screenshots). 

This could be a serious problem, particularly when backstop assertions are run as part of tests suite in CI/CD pipeline.

This PR is to flip the default behaviour from backstop assertions running by default to _not running_ by default. To opt-in to run backstop assertions(take screenshots), please refer to the steps in `README`.