### PR TITLE
also copy checkbox/radio "checked" DOM attribute to the snapshot

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -18,3 +18,6 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+# backstop files
+/ember-backstop

--- a/addon-test-support/backstop.js
+++ b/addon-test-support/backstop.js
@@ -22,14 +22,22 @@ function copyAttributesToBodyCopy(bodyCopy, testingContainer) {
   Object.keys(attributesToCopy).forEach(key => copyAttr(attributesToCopy[key]));
 }
 
-function prepareInputValuesForCopying(snapshotRoot) {
+/**
+ * Sync JS properties to HTML attributes, so Backstop can see it
+ * @param snapshotRoot
+ */
+  export function prepareInputValuesForCopying(snapshotRoot) {
   snapshotRoot.querySelectorAll('input')
     .forEach(function (item) {
       item.setAttribute('value', item.value);
-      if (item.checked) {
-        item.setAttribute('checked', 'checked');
-      } else {
-        item.removeAttribute('checked');
+      if (item.type === 'radio' || item.type === 'checkbox') {
+        if (item.checked) {
+          item.setAttribute('checked', 'checked');
+        } else {
+          item.removeAttribute('checked');
+        }
+        // note: can't handle `indeterminate` state, as there
+        // is no such HTML attribute
       }
     });
 }

--- a/addon-test-support/backstop.js
+++ b/addon-test-support/backstop.js
@@ -26,6 +26,9 @@ function prepareInputValuesForCopying(snapshotRoot) {
   snapshotRoot.querySelectorAll('input')
     .forEach(function (item) {
       item.setAttribute('value', item.value);
+      if (item.checked) {
+        item.setAttribute('checked', 'checked');
+      }
     });
 }
 

--- a/addon-test-support/backstop.js
+++ b/addon-test-support/backstop.js
@@ -28,6 +28,8 @@ function prepareInputValuesForCopying(snapshotRoot) {
       item.setAttribute('value', item.value);
       if (item.checked) {
         item.setAttribute('checked', 'checked');
+      } else {
+        item.removeAttribute('checked');
       }
     });
 }

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -6,10 +6,11 @@ import backstop from 'ember-backstop/test-support/backstop';
 module('Acceptance | list rentals', function(hooks) {
   setupApplicationTest(hooks);
 
-  test('Simple tests.', async function(assert) {
+  test('Should load the app and should match previously approved reference.', async function(assert) {
     await visit('/');
     await backstop(assert);
     assert.equal(currentURL(), '/', 'URL should be at root.');
     assert.dom(this.element.querySelector('#title')).hasText('Welcome to Ember');
   });
+
 });

--- a/tests/unit/addon-test-support/backstop-test.js
+++ b/tests/unit/addon-test-support/backstop-test.js
@@ -9,28 +9,26 @@ module('Unit | Addon Test Support', hooks => {
 
     test('Should copy JS DOM attributes into snapshot DOM attribute', async function(assert) {
 
-      // Given DOM node with HTML inputs without
-      // default attribute values provided
+      // Given DOM node with HTML inputs
       var snapshot = document.createElement('form');
       snapshot.innerHTML = `
         <input type="radio" id="checkbox1" />
         <input type="radio" id="radio1" />
-        <input type="checkbox" id="checkbox2"/>
-        <input type="checkbox" id="radio2"/>
+        <input type="checkbox" id="checkbox2" checked />
         <input type="text" id="text1"/>
         <input type="button" id="button1"/>
       `;
 
       // Given `value` and `checked` attributes are
-      // set programmatically as JS props
+      // changed programmatically
       snapshot['radio1'].value = 'radio value 1';
       snapshot['radio1'].checked = true;
 
       snapshot['checkbox1'].value = 'checkbox value 1';
       snapshot['checkbox1'].checked = true;
 
-      snapshot['radio2'].value = 'radio value 2';
       snapshot['checkbox2'].value = 'checkbox value 2';
+      snapshot['checkbox2'].checked = false;
 
       snapshot['text1'].value = 'text value';
       snapshot['button1'].value = 'button value';
@@ -45,9 +43,11 @@ module('Unit | Addon Test Support', hooks => {
       assert.equal(snapshot['checkbox1'].getAttribute('value'), 'checkbox value 1');
       assert.equal(snapshot['checkbox1'].hasAttribute('checked'), true);
 
-      assert.equal(snapshot['radio2'].getAttribute('value'), 'radio value 2');
       assert.equal(snapshot['checkbox2'].getAttribute('value'), 'checkbox value 2');
+      assert.equal(snapshot['checkbox2'].hasAttribute('checked'), false);
+
       assert.equal(snapshot['text1'].getAttribute('value'), 'text value');
+
       assert.equal(snapshot['button1'].getAttribute('value'), 'button value');
       assert.equal(snapshot['button1'].hasAttribute('checked'), false);
     });

--- a/tests/unit/addon-test-support/backstop-test.js
+++ b/tests/unit/addon-test-support/backstop-test.js
@@ -1,0 +1,57 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { prepareInputValuesForCopying } from 'ember-backstop/test-support/backstop';
+
+module('Unit | Addon Test Support', hooks => {
+  setupTest(hooks);
+
+  module('#prepareInputValuesForCopying tests', () => {
+
+    test('Should copy JS DOM attributes into snapshot DOM attribute', async function(assert) {
+
+      // Given DOM node with HTML inputs without
+      // default attribute values provided
+      var snapshot = document.createElement('form');
+      snapshot.innerHTML = `
+        <input type="radio" id="checkbox1" />
+        <input type="radio" id="radio1" />
+        <input type="checkbox" id="checkbox2"/>
+        <input type="checkbox" id="radio2"/>
+        <input type="text" id="text1"/>
+        <input type="button" id="button1"/>
+      `;
+
+      // Given `value` and `checked` attributes are
+      // set programmatically as JS props
+      snapshot['radio1'].value = 'radio value 1';
+      snapshot['radio1'].checked = true;
+
+      snapshot['checkbox1'].value = 'checkbox value 1';
+      snapshot['checkbox1'].checked = true;
+
+      snapshot['radio2'].value = 'radio value 2';
+      snapshot['checkbox2'].value = 'checkbox value 2';
+
+      snapshot['text1'].value = 'text value';
+      snapshot['button1'].value = 'button value';
+      snapshot['button1'].checked = true; // unsupported "checked" attribute for a button
+
+      // When function is called with given snapshot
+      prepareInputValuesForCopying(snapshot);
+
+      assert.equal(snapshot['radio1'].getAttribute('value'), 'radio value 1');
+      assert.equal(snapshot['radio1'].hasAttribute('checked'), true);
+
+      assert.equal(snapshot['checkbox1'].getAttribute('value'), 'checkbox value 1');
+      assert.equal(snapshot['checkbox1'].hasAttribute('checked'), true);
+
+      assert.equal(snapshot['radio2'].getAttribute('value'), 'radio value 2');
+      assert.equal(snapshot['checkbox2'].getAttribute('value'), 'checkbox value 2');
+      assert.equal(snapshot['text1'].getAttribute('value'), 'text value');
+      assert.equal(snapshot['button1'].getAttribute('value'), 'button value');
+      assert.equal(snapshot['button1'].hasAttribute('checked'), false);
+    });
+
+  });
+
+});


### PR DESCRIPTION
See https://github.com/garris/ember-backstop/issues/41
Basically, explicitly synchronizing "checked" JS attribute back to the DOM in the snapshot - so it could be enabled by default when rendered in Chromium/Chrome.

Ref: https://stackoverflow.com/a/4882020/3785649

Here is a gif screencast to show that DOM does not update when user interacts with checkbox:
![test](https://user-images.githubusercontent.com/5897153/80249807-5e2bd980-8627-11ea-8d6a-e6bf759bc93b.gif)
