### PR TITLE
fix attributes not being copied from a container to a body

### DIFF
--- a/addon-test-support/backstop.js
+++ b/addon-test-support/backstop.js
@@ -9,15 +9,14 @@ const BACKSTOP_REPORT_URL = 'backstop/backstop_data/html_report/';
 // styling). In tests these attributes are added to the #ember-testing container and would be lost
 // in the DOM hoisting, so we copy them to the to the snapshot's <body> tag to
 // make sure that they persist in the DOM snapshot.
-function copyAttributesToBodyCopy(bodyCopy, testingContainer) {
+export function copyAttributesToBodyCopy(bodyCopy, testingContainer) {
   let attributesToCopy = testingContainer.attributes;
   const copyAttr = function(thisAttr) {
     // Special case for the class attribute - append new classes onto existing body classes
-    if (thisAttr.name === 'class') {
-      bodyCopy[thisAttr.name] = bodyCopy[thisAttr.name] + ' ' + thisAttr.value;
-    } else {
-      bodyCopy[thisAttr.name] = thisAttr.value;
+    if (thisAttr.name !== 'class') {
+      bodyCopy.setAttribute(thisAttr.name, thisAttr.value);
     }
+    bodyCopy.classList.add(...testingContainer.classList);
   };
   Object.keys(attributesToCopy).forEach(key => copyAttr(attributesToCopy[key]));
 }

--- a/addon-test-support/backstop.js
+++ b/addon-test-support/backstop.js
@@ -12,10 +12,10 @@ const BACKSTOP_REPORT_URL = 'backstop/backstop_data/html_report/';
 export function copyAttributesToBodyCopy(bodyCopy, testingContainer) {
   let attributesToCopy = testingContainer.attributes;
   const copyAttr = function(thisAttr) {
-    // Special case for the class attribute - append new classes onto existing body classes
     if (thisAttr.name !== 'class') {
       bodyCopy.setAttribute(thisAttr.name, thisAttr.value);
     }
+    // Special case for the class attribute - append new classes onto existing body classes
     bodyCopy.classList.add(...testingContainer.classList);
   };
   Object.keys(attributesToCopy).forEach(key => copyAttr(attributesToCopy[key]));

--- a/tests/unit/addon-test-support/backstop-test.js
+++ b/tests/unit/addon-test-support/backstop-test.js
@@ -85,6 +85,15 @@ module('Unit | Addon Test Support', hooks => {
       copyAttributesToBodyCopy(body, testingContainer);
       assert.equal(body.getAttribute('class'), 'new-class1 new-class2');
     });
+
+    test('Should not introduce classes to a body if neither body or container had classes', async function(assert) {
+      const sourceDocument = document.implementation.createHTMLDocument("Testem page");
+      const body = sourceDocument.body;
+      body.innerHTML = '<div><div id="testing-container"></div></div>';
+      const testingContainer = sourceDocument.getElementById('testing-container');
+      copyAttributesToBodyCopy(body, testingContainer);
+      assert.equal(body.getAttribute('class'), '');
+    });
   });
 
 });

--- a/tests/unit/addon-test-support/backstop-test.js
+++ b/tests/unit/addon-test-support/backstop-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { prepareInputValuesForCopying } from 'ember-backstop/test-support/backstop';
+import { prepareInputValuesForCopying, copyAttributesToBodyCopy } from 'ember-backstop/test-support/backstop';
 
 module('Unit | Addon Test Support', hooks => {
   setupTest(hooks);
@@ -52,6 +52,39 @@ module('Unit | Addon Test Support', hooks => {
       assert.equal(snapshot['button1'].hasAttribute('checked'), false);
     });
 
+  });
+
+  module('#copyAttributesToBodyCopy tests', () => {
+    test('Should copy HTML attributes from a container element to a body', async function(assert) {
+      const sourceDocument = document.implementation.createHTMLDocument("Testem page");
+      const body = sourceDocument.body;
+      body.innerHTML = '<div><div id="testing-container" data-custom-attribute="val1" nonstandardattribute="val2" attributewithoutvalue></div></div>';
+      const testingContainer = sourceDocument.getElementById('testing-container');
+      copyAttributesToBodyCopy(body, testingContainer);
+      assert.equal(body.getAttribute('id'), 'testing-container');
+      assert.equal(body.getAttribute('data-custom-attribute'), 'val1');
+      assert.equal(body.getAttribute('nonstandardattribute'), 'val2');
+      assert.equal(body.hasAttribute('attributewithoutvalue'), true);
+    });
+
+    test('Should append classes from a container to a body which had pre-existing classes', async function(assert) {
+      const sourceDocument = document.implementation.createHTMLDocument("Testem page");
+      const body = sourceDocument.body;
+      body.setAttribute('class', 'original-class1 original-class2')
+      body.innerHTML = '<div><div id="testing-container" class="new-class1 new-class2"></div></div>';
+      const testingContainer = sourceDocument.getElementById('testing-container');
+      copyAttributesToBodyCopy(body, testingContainer);
+      assert.equal(body.getAttribute('class'), 'original-class1 original-class2 new-class1 new-class2');
+    });
+
+    test('Should append classes from a container to a body which had no classes', async function(assert) {
+      const sourceDocument = document.implementation.createHTMLDocument("Testem page");
+      const body = sourceDocument.body;
+      body.innerHTML = '<div><div id="testing-container" class="new-class1 new-class2"></div></div>';
+      const testingContainer = sourceDocument.getElementById('testing-container');
+      copyAttributesToBodyCopy(body, testingContainer);
+      assert.equal(body.getAttribute('class'), 'new-class1 new-class2');
+    });
   });
 
 });


### PR DESCRIPTION
I noticed that `ember-application` class is present in the production application's `body`, and on the testem container  - but not on the `body` of HTML rendered in backstop's chrome.
This was messing up some styles - in my app I had styles which are applied to `ember-application` class.

After digging further, I found that attributes are not copied over as HTML attributes.

This was not noticed before likely because the main attribute (id) can be set both as an HTML attribute AND as a property.