### PR TITLE
Support screenshots generation without comparing against baselines

### DIFF
--- a/addon-test-support/backstop.js
+++ b/addon-test-support/backstop.js
@@ -1,7 +1,8 @@
 import { later } from '@ember/runloop';
 
 const ORIGIN = window.location.origin;
-const BACKSTOP_DYNAMIC_TEST_URL = 'backstop/dtest';
+const { screenshotsOnly } = getAddonCfgFromParentApp();
+const BACKSTOP_DYNAMIC_TEST_URL = screenshotsOnly ? 'backstop/dref': 'backstop/dtest';
 const BACKSTOP_REPORT_URL = 'backstop/backstop_data/html_report/';
 
 // Copy attributes from Ember's rootElement to the DOM snapshot <body> tag. Some applications rely

--- a/addon-test-support/backstop.js
+++ b/addon-test-support/backstop.js
@@ -137,7 +137,8 @@ function backstopHelper(name, testHash, options, res, err) {
     enableJavaScript: options.enableJavaScript,
     testHash: testHash,
     origin: ORIGIN,
-    scenario: options.scenario
+    scenario: options.scenario,
+    i: screenshotsOnly
   });
 
   later(function() {

--- a/commands/backstop-remote.js
+++ b/commands/backstop-remote.js
@@ -3,17 +3,19 @@ const backstopjs = require('backstopjs');
 
 module.exports = {
   name: 'backstop:remote',
+
   aliases: ['backstop-remote'],
+
   availableOptions: [
-    { name: 'filter', type: String, aliases: ['f'], default: ''},
-    { name: 'config', type: String, aliases: ['c'], default: './backstop.js' }
+    { name: 'filter', type: String, aliases: ['f'], default: '' },
+    { name: 'config', type: String, aliases: ['c'], default: './backstop.js' },
+    { name: 'i', type: Boolean },
   ],
+
   description: 'Launch Backstop-Remote server.',
-  run(commandOptions) {
+
+  run({ config, filter, i }) {
     process.chdir('./ember-backstop');
-    return backstopjs('remote', {
-      config: commandOptions.config, 
-      filter: commandOptions.filter
-    });
-  }
+    return backstopjs('remote', { config, filter, i });
+  },
 };

--- a/commands/backstop-remote.js
+++ b/commands/backstop-remote.js
@@ -9,13 +9,12 @@ module.exports = {
   availableOptions: [
     { name: 'filter', type: String, aliases: ['f'], default: '' },
     { name: 'config', type: String, aliases: ['c'], default: './backstop.js' },
-    { name: 'i', type: Boolean },
   ],
 
   description: 'Launch Backstop-Remote server.',
 
-  run({ config, filter, i }) {
+  run({ config, filter }) {
     process.chdir('./ember-backstop');
-    return backstopjs('remote', { config, filter, i });
+    return backstopjs('remote', { config, filter });
   },
 };


### PR DESCRIPTION
prerequisite PR: https://github.com/garris/BackstopJS/pull/1216

**Changes** include:

- introduce support for a new config key(`screenshotsOnly`) in the consuming app/addon which can be used to use backstop to generate only screenshots without having to compare screenshots against a certain baseline screenshot
- pass interactive mode option to backstop remote in backstop-remote command