### PR TITLE
Support usage of testId option when creating the testHash

### DIFF
--- a/addon-test-support/backstop.js
+++ b/addon-test-support/backstop.js
@@ -169,7 +169,7 @@ function backstopHelper(name, testHash, options, res, err) {
   }, 0);
 }
 
-function createNameHash(assert, options) {
+export function createNameHash(assert, options) {
   if (!assert) {
     throw new Error("Backstop helper requires an assert object");
   }
@@ -195,7 +195,7 @@ function createNameHash(assert, options) {
     assert.test.module.name &&
     assert.test.testName
   ) {
-    testHash.testId = window._testRunTime;
+    testHash.testId = options.testId ?? window._testRunTime;
     testHash.scenarioId = assert.test.testId;
     assertionName = `${assert.test.module.name} | ${assert.test.testName}`;
   }

--- a/tests/unit/addon-test-support/backstop-test.js
+++ b/tests/unit/addon-test-support/backstop-test.js
@@ -1,14 +1,16 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { prepareInputValuesForCopying, copyAttributesToBodyCopy } from 'ember-backstop/test-support/backstop';
+import {
+  prepareInputValuesForCopying,
+  copyAttributesToBodyCopy,
+  createNameHash,
+} from 'ember-backstop/test-support/backstop';
 
-module('Unit | Addon Test Support', hooks => {
+module('Unit | Addon Test Support', (hooks) => {
   setupTest(hooks);
 
   module('#prepareInputValuesForCopying tests', () => {
-
-    test('Should copy JS DOM attributes into snapshot DOM attribute', async function(assert) {
-
+    test('Should copy JS DOM attributes into snapshot DOM attribute', async function (assert) {
       // Given DOM node with HTML inputs
       var snapshot = document.createElement('form');
       snapshot.innerHTML = `
@@ -40,10 +42,16 @@ module('Unit | Addon Test Support', hooks => {
       assert.equal(snapshot['radio1'].getAttribute('value'), 'radio value 1');
       assert.equal(snapshot['radio1'].hasAttribute('checked'), true);
 
-      assert.equal(snapshot['checkbox1'].getAttribute('value'), 'checkbox value 1');
+      assert.equal(
+        snapshot['checkbox1'].getAttribute('value'),
+        'checkbox value 1'
+      );
       assert.equal(snapshot['checkbox1'].hasAttribute('checked'), true);
 
-      assert.equal(snapshot['checkbox2'].getAttribute('value'), 'checkbox value 2');
+      assert.equal(
+        snapshot['checkbox2'].getAttribute('value'),
+        'checkbox value 2'
+      );
       assert.equal(snapshot['checkbox2'].hasAttribute('checked'), false);
 
       assert.equal(snapshot['text1'].getAttribute('value'), 'text value');
@@ -51,15 +59,17 @@ module('Unit | Addon Test Support', hooks => {
       assert.equal(snapshot['button1'].getAttribute('value'), 'button value');
       assert.equal(snapshot['button1'].hasAttribute('checked'), false);
     });
-
   });
 
   module('#copyAttributesToBodyCopy tests', () => {
-    test('Should copy HTML attributes from a container element to a body', async function(assert) {
-      const sourceDocument = document.implementation.createHTMLDocument("Testem page");
+    test('Should copy HTML attributes from a container element to a body', async function (assert) {
+      const sourceDocument =
+        document.implementation.createHTMLDocument('Testem page');
       const body = sourceDocument.body;
-      body.innerHTML = '<div><div id="testing-container" data-custom-attribute="val1" nonstandardattribute="val2" attributewithoutvalue></div></div>';
-      const testingContainer = sourceDocument.getElementById('testing-container');
+      body.innerHTML =
+        '<div><div id="testing-container" data-custom-attribute="val1" nonstandardattribute="val2" attributewithoutvalue></div></div>';
+      const testingContainer =
+        sourceDocument.getElementById('testing-container');
       copyAttributesToBodyCopy(body, testingContainer);
       assert.equal(body.getAttribute('id'), 'testing-container');
       assert.equal(body.getAttribute('data-custom-attribute'), 'val1');
@@ -67,33 +77,68 @@ module('Unit | Addon Test Support', hooks => {
       assert.equal(body.hasAttribute('attributewithoutvalue'), true);
     });
 
-    test('Should append classes from a container to a body which had pre-existing classes', async function(assert) {
-      const sourceDocument = document.implementation.createHTMLDocument("Testem page");
+    test('Should append classes from a container to a body which had pre-existing classes', async function (assert) {
+      const sourceDocument =
+        document.implementation.createHTMLDocument('Testem page');
       const body = sourceDocument.body;
-      body.setAttribute('class', 'original-class1 original-class2')
-      body.innerHTML = '<div><div id="testing-container" class="new-class1 new-class2"></div></div>';
-      const testingContainer = sourceDocument.getElementById('testing-container');
+      body.setAttribute('class', 'original-class1 original-class2');
+      body.innerHTML =
+        '<div><div id="testing-container" class="new-class1 new-class2"></div></div>';
+      const testingContainer =
+        sourceDocument.getElementById('testing-container');
       copyAttributesToBodyCopy(body, testingContainer);
-      assert.equal(body.getAttribute('class'), 'original-class1 original-class2 new-class1 new-class2');
+      assert.equal(
+        body.getAttribute('class'),
+        'original-class1 original-class2 new-class1 new-class2'
+      );
     });
 
-    test('Should append classes from a container to a body which had no classes', async function(assert) {
-      const sourceDocument = document.implementation.createHTMLDocument("Testem page");
+    test('Should append classes from a container to a body which had no classes', async function (assert) {
+      const sourceDocument =
+        document.implementation.createHTMLDocument('Testem page');
       const body = sourceDocument.body;
-      body.innerHTML = '<div><div id="testing-container" class="new-class1 new-class2"></div></div>';
-      const testingContainer = sourceDocument.getElementById('testing-container');
+      body.innerHTML =
+        '<div><div id="testing-container" class="new-class1 new-class2"></div></div>';
+      const testingContainer =
+        sourceDocument.getElementById('testing-container');
       copyAttributesToBodyCopy(body, testingContainer);
       assert.equal(body.getAttribute('class'), 'new-class1 new-class2');
     });
 
-    test('Should not introduce classes to a body if neither body or container had classes', async function(assert) {
-      const sourceDocument = document.implementation.createHTMLDocument("Testem page");
+    test('Should not introduce classes to a body if neither body or container had classes', async function (assert) {
+      const sourceDocument =
+        document.implementation.createHTMLDocument('Testem page');
       const body = sourceDocument.body;
       body.innerHTML = '<div><div id="testing-container"></div></div>';
-      const testingContainer = sourceDocument.getElementById('testing-container');
+      const testingContainer =
+        sourceDocument.getElementById('testing-container');
       copyAttributesToBodyCopy(body, testingContainer);
       assert.equal(body.getAttribute('class'), '');
     });
   });
 
+  module('#createNameHash tests', () => {
+    test('Should not automatically generate the testId when specified', async function (assert) {
+      const obj = createNameHash(assert, { name: 'Snapshot', testId: '1337' });
+      assert.deepEqual(obj, {
+        name: 'Unit | Addon Test Support > #createNameHash tests | Should not automatically generate the testId when specified | Snapshot | assert0',
+        testHash: {
+          scenarioId: '64825016',
+          testId: '1337',
+        },
+      });
+    });
+
+    test('Should automatically generate the testId when not specified', async function (assert) {
+      window._testRunTime = '20230517-171000';
+      const obj = createNameHash(assert, { name: 'Snapshot' });
+      assert.deepEqual(obj, {
+        name: 'Unit | Addon Test Support > #createNameHash tests | Should automatically generate the testId when not specified | Snapshot | assert0',
+        testHash: {
+          scenarioId: 'dc62a95c',
+          testId: '20230517-171000',
+        },
+      });
+    });
+  });
 });


### PR DESCRIPTION
This Pull Request does the following:

- solves problem identified in the following issue: https://github.com/garris/ember-backstop/issues/82
- adds regression tests for old behavior
- adds new test for the new behavior