### PR TITLE
fix: prevent undefined error when no options are given

### DIFF
--- a/addon-test-support/backstop.js
+++ b/addon-test-support/backstop.js
@@ -195,7 +195,7 @@ export function createNameHash(assert, options) {
     assert.test.module.name &&
     assert.test.testName
   ) {
-    testHash.testId = options.testId ?? window._testRunTime;
+    testHash.testId = options?.testId ?? window._testRunTime;
     testHash.scenarioId = assert.test.testId;
     assertionName = `${assert.test.module.name} | ${assert.test.testName}`;
   }

--- a/tests/unit/addon-test-support/backstop-test.js
+++ b/tests/unit/addon-test-support/backstop-test.js
@@ -140,5 +140,18 @@ module('Unit | Addon Test Support', (hooks) => {
         },
       });
     });
+
+     test.only('Should automatically generate the testId when no options are given', async function (assert) {
+      window._testRunTime = '20230517-171000';
+      const obj = createNameHash(assert);
+      assert.deepEqual(obj, {
+        name: 'Unit | Addon Test Support > #createNameHash tests | Should automatically generate the testId when no options are given | assert0',
+        testHash: {
+          scenarioId: '2f7a5c37',
+          testId: '20230517-171000',
+        },
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Fixes #84 